### PR TITLE
Add automated setup script for lip-reading model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+chaplin/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project is a complete setup for real-time lip-reading using the Chaplin model and optional integration with language models (LLMs) via Ollama.
 
+## 🚀 Quick Start
+
+```bash
+git clone <REPO_URL>
+cd Lip-Read
+./run.sh
+```
+
+The `run.sh` script automatically downloads the Chaplin repository, creates a Python virtual environment, installs the required Python packages, and launches the demo. To prepare the environment without running the model, use:
+
+```bash
+./run.sh --no-run
+```
+
 ## 🔗 Components
 - **Chaplin (Core Model)**: https://github.com/amanvirparhar/chaplin
 - **CUDA Toolkit (GPU acceleration)**: https://developer.nvidia.com/cuda-downloads
@@ -10,7 +24,7 @@ This project is a complete setup for real-time lip-reading using the Chaplin mod
 - **PyTorch (Deep Learning Engine)**: https://pytorch.org/get-started/locally/
 - **Ollama (LLM support)**: https://ollama.com/download/windows
 
-## 🚀 Setup Instructions
+## 📁 Manual Setup
 1. Install dependencies using files in the `install/` folder.
 2. Clone the repo and create a virtual environment.
-3. Run `chaplin/main.py` to begin.
+3. Download the Chaplin repository into `chaplin/` and run `chaplin/main.py` to begin.

--- a/chaplin/main.py
+++ b/chaplin/main.py
@@ -1,1 +1,0 @@
-print("Running Chaplin Lip-Reading AI")

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Simple setup and execution script for the Lip-Read project
+set -e
+
+# Clone Chaplin repository if missing
+if [ ! -d "chaplin/.git" ]; then
+  echo "Downloading Chaplin model repository..."
+  rm -rf chaplin
+  git clone --depth 1 https://github.com/amanvirparhar/chaplin chaplin
+fi
+
+# Create Python virtual environment if needed
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+# Install Python dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+if [ "$1" != "--no-run" ]; then
+  python chaplin/main.py "$@"
+else
+  echo "Environment setup complete. Run the model with ./run.sh"
+fi


### PR DESCRIPTION
## Summary
- add `run.sh` to download Chaplin, create a virtual environment, install Python dependencies, and optionally launch the demo
- document new quick-start path using the script and clarify manual setup steps
- ignore local `chaplin/` checkout and virtual environment

## Testing
- `bash run.sh --no-run`


------
https://chatgpt.com/codex/tasks/task_b_688edd7273bc833295ec488735c2c347