### PR TITLE
Add Makefile for Windows setup and docs on make usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Makefile for Lip-Read project
+
+# Determine OS-specific paths
+VENV_DIR := .venv
+ifeq ($(OS),Windows_NT)
+	PYTHON := $(VENV_DIR)/Scripts/python.exe
+else
+	PYTHON := $(VENV_DIR)/bin/python
+endif
+
+.PHONY: setup run clean
+
+chaplin/.git:
+	git clone --depth 1 https://github.com/amanvirparhar/chaplin chaplin
+
+$(VENV_DIR):
+	python -m venv $(VENV_DIR)
+
+setup: chaplin/.git $(VENV_DIR)
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -r requirements.txt
+	@echo "Setup complete. Use 'make run' to start the demo."
+
+run: setup
+	$(PYTHON) chaplin/main.py
+
+clean:
+	rm -rf chaplin $(VENV_DIR)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ The `run.sh` script automatically downloads the Chaplin repository, creates a Py
 ./run.sh --no-run
 ```
 
+### Windows 11 with Make
+
+If you're using Git Bash or another environment with `make`, you can set up and run the demo using:
+
+```bash
+make setup   # downloads Chaplin and installs dependencies
+make run     # launches the lip-reading demo
+```
+
 ## 🔗 Components
 - **Chaplin (Core Model)**: https://github.com/amanvirparhar/chaplin
 - **CUDA Toolkit (GPU acceleration)**: https://developer.nvidia.com/cuda-downloads


### PR DESCRIPTION
## Summary
- add cross-platform Makefile with setup, run, and clean targets
- document using `make` on Windows 11

## Testing
- `make setup`
- `make run` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_688edf7123748332b386f922f7918a9b