### PR TITLE
Install Chaplin dependencies

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,7 @@ source .venv/bin/activate
 # Install Python dependencies
 pip install --upgrade pip
 pip install -r requirements.txt
+pip install -r chaplin/requirements.txt
 
 if [ "$1" != "--no-run" ]; then
   python chaplin/main.py "$@"


### PR DESCRIPTION
## Summary
- install Chaplin's required Python packages

## Testing
- `./run.sh --no-run`


------
https://chatgpt.com/codex/tasks/task_b_688ee1e1d8b4833287a39b35c0c8b6c2