### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+.venv/
+__pycache__/
+chaplin/
+*.ckpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir requests
+
+# Clone Chaplin repository and install its requirements
+RUN git clone --depth 1 https://github.com/amanvirparhar/chaplin chaplin \
+    && pip install --no-cache-dir -r chaplin/requirements.txt
+
+# Download model weights and configuration
+RUN python - <<'PYCODE'
+import requests, os
+from tqdm import tqdm
+
+def download(url, path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    r = requests.get(url, stream=True)
+    r.raise_for_status()
+    total = int(r.headers.get('content-length', 0))
+    with open(path, 'wb') as f, tqdm(total=total, unit='B', unit_scale=True, unit_divisor=1024, desc=path) as bar:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)
+                bar.update(len(chunk))
+
+download('https://storage.googleapis.com/chaplin-vsr/vsr_v2.ckpt', 'chaplin/models/vsr_v2.ckpt')
+download('https://storage.googleapis.com/chaplin-vsr/vsr_v2.yaml', 'chaplin/configs/vsr_v2.yaml')
+PYCODE
+
+# Copy project files
+COPY . .
+
+CMD ["python", "chaplin/main.py", "--config-path=configs", "--config-name=vsr_v2.yaml"]

--- a/README.md
+++ b/README.md
@@ -59,3 +59,26 @@ make run     # launches the lip-reading demo
    python chaplin/main.py
    ```
    Running `./run.sh` executes these steps automatically and starts the model unless you pass `--no-run`.
+
+## 🐳 Docker
+
+A Dockerfile is included to run the demo inside a container.
+
+Build the image:
+
+```bash
+docker build -t lip-read .
+```
+
+Run the demo:
+
+```bash
+docker run --rm -it lip-read
+```
+
+To upload the image to Docker Hub:
+
+```bash
+docker tag lip-read <your-username>/lip-read:latest
+docker push <your-username>/lip-read:latest
+```


### PR DESCRIPTION
## Summary
- add Dockerfile that installs dependencies, Chaplin model, and downloads weights
- ignore local virtual environments and artifacts in .dockerignore
- document Docker image build, run, and push instructions

## Testing
- `bash -n run.sh`
- `docker --version`
- `docker build -t lip-read .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_b_688f8d3104a08332ad7dfc7352e4a707